### PR TITLE
Fix country case according to ISO 3166-1 alpha-2

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Aula",
-    "country": "dk",
+    "country": "DK",
     "render_readme": true,
     "homeassistant": "2022.9.0",
     "zip_release": true,


### PR DESCRIPTION
Country codes are using capital letters in ISO 3166-1 alpha-2