### PR TITLE
Meebook weekplan service

### DIFF
--- a/custom_components/aula/client.py
+++ b/custom_components/aula/client.py
@@ -257,9 +257,9 @@ class Client:
 
             def ugeplan(week,thisnext):
 
-                def set_meebook_weekplan_attr(person, weekplan_data):
+                def set_meebook_weekplan_attr(person_name, weekplan_data):
                     # Convert to datetime from strings like "mandag 2. okt." (Don't use setLocale as it will affect all of HA)
-                    def datetime_from_meebook_str(str):
+                    def date_from_meebook_str(str):
                         monthsArr = [
                             "jan",
                             "feb",
@@ -274,7 +274,7 @@ class Client:
                             "nov",
                             "dec",
                         ]
-                        today = datetime.datetime.now()
+                        today = datetime.date.today()
                         date_re = re.search("[a-z]* (\d*)\. ([a-z]*)\.", str)
                         dayInMonth = int(date_re.group(1))
                         month = monthsArr.index(date_re.group(2)) + 1
@@ -286,8 +286,7 @@ class Client:
                         return datetime.date(year, month, dayInMonth)
 
                     for day in weekplan_data:
-                        # day["date"] = datetime_from_meebook_str(day["date"])
-                        dt = datetime_from_meebook_str(day["date"])
+                        dt = date_from_meebook_str(day["date"])
 
                         # clean up fields
                         for task in day["tasks"]:
@@ -295,8 +294,8 @@ class Client:
                             del task["editUrl"]
 
                         dt_dict = self.meebook_weekplan.setdefault(
-                            person, {}
-                        ).setdefault(dt, {})
+                            person_name, {}
+                                ).setdefault(dt, {})
                         dt_dict["tasks"] = day["tasks"]
 
                 if "0029" in self.widgets:
@@ -424,7 +423,7 @@ class Client:
                         elif thisnext == "next":
                             self.ugepnext_attr[name] = ugep
 
-                        set_meebook_weekplan_attr(name, person["weekPlan"])
+                        set_meebook_weekplan_attr(person["name"], person["weekPlan"])
 
             now = datetime.datetime.now() + datetime.timedelta(weeks=1)
             thisweek = datetime.datetime.now().strftime('%Y-W%W')

--- a/custom_components/aula/helpers.py
+++ b/custom_components/aula/helpers.py
@@ -1,0 +1,9 @@
+import datetime
+
+def get_this_week_start_date():
+    today = datetime.date.today()
+    week_start_date = today - datetime.timedelta(days = today.weekday())
+    return week_start_date
+
+def get_next_week_start_date():
+    return get_this_week_start_date() + datetime.timedelta(weeks = 1)

--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant import config_entries, core
 from .client import Client
+from . import helpers
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -174,8 +175,7 @@ class AulaSensor(Entity):
 
         fields = ['location', 'sleepIntervals', 'checkInTime', 'checkOutTime', 'activityType', 'entryTime', 'exitTime', 'exitWith', 'comment', 'spareTimeActivity', 'selfDeciderStartTime', 'selfDeciderEndTime']
         attributes = {}
-        #_LOGGER.debug("Dump of ugep_attr: "+str(self._client.ugep_attr))
-        #_LOGGER.debug("Dump of ugepnext_attr: "+str(self._client.ugepnext_attr))
+        #_LOGGER.debug("Dump of weekplans_html: "+str(self._client.weekplans_html))
         if ugeplan:
             if "0062" in self._client.widgets:
                 try:
@@ -183,11 +183,11 @@ class AulaSensor(Entity):
                 except:
                     attributes["huskelisten"] = "Not available"
             try:
-                attributes["ugeplan"] = self._client.ugep_attr[self._child["name"].split()[0]]
+                attributes["ugeplan"] = self._client.weekplans_html[self._child["name"].split()[0]][helpers.get_this_week_start_date()]
             except:
                 attributes["ugeplan"] = "Not available"
             try:
-                attributes["ugeplan_next"] = self._client.ugepnext_attr[self._child["name"].split()[0]]
+                attributes["ugeplan"] = self._client.weekplans_html[self._child["name"].split()[0]][helpers.get_next_week_start_date()]
             except:
                 attributes["ugeplan_next"] = "Not available"
                 _LOGGER.debug("Could not get ugeplan for next week for child "+str(self._child["name"].split()[0])+". Perhaps not available yet.")

--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -230,7 +230,22 @@ class AulaSensor(Entity):
         try:
             name = self._child["name"].split()[0]
             plan = self._client.meebook_weekplan[name]
-            return {"entries": {day: tasks for day, tasks in plan.items() if day >= start_date and day <= end_date and len(tasks["tasks"]) > 0 }}
+            result = {"entries": {day: tasks for day, tasks in plan.items() if day >= start_date and day <= end_date and len(tasks["tasks"]) > 0 }}
+
+            warnings = []
+            if len(plan) == 0:
+                warnings.append("No plan found")
+            else:
+                # check if data requested outside bounds of existing data
+                date_lower = min(plan.keys())
+                date_upper = max(plan.keys())
+                if start_date < date_lower or end_date > date_upper:
+                    warnings.append(f"Start or end date is outside available data range: {date_lower} - {date_upper}")
+
+            if len(warnings) > 0:
+                result["warnings"] = warnings
+
+            return result
         except:
             return {}
 

--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -108,27 +108,28 @@ async def async_setup_entry(
 
 
     # Set up services
-    platform = entity_platform.async_get_current_platform()
-    async def meebook_list_events_service(service_call: core.ServiceCall) -> core.ServiceResponse:
-        """Search in the date range and return the matching items."""
-        start = service_call.data.get(EVENT_START_DATE, dt_util.now().date())
-        if EVENT_DURATION in service_call.data:
-            end = start + service_call.data[EVENT_DURATION]
-        else:
-            end = service_call.data[EVENT_END_DATE]
+    if len(client.meebook_weekplan) > 0:
+        platform = entity_platform.async_get_current_platform()
+        async def meebook_list_events_service(service_call: core.ServiceCall) -> core.ServiceResponse:
+            """Search in the date range and return the matching items."""
+            start = service_call.data.get(EVENT_START_DATE, dt_util.now().date())
+            if EVENT_DURATION in service_call.data:
+                end = start + service_call.data[EVENT_DURATION]
+            else:
+                end = service_call.data[EVENT_END_DATE]
 
-        sensors = await platform.async_extract_from_service(service_call)
-        sensor = sensors[0]
+            sensors = await platform.async_extract_from_service(service_call)
+            sensor = sensors[0]
 
-        return await sensor.async_get_meebook_weekplan(start, end)
+            return await sensor.async_get_meebook_weekplan(start, end)
 
-    hass.services.async_register(
-        DOMAIN,
-        LIST_MEEBOOK_EVENTS_SERVICE_NAME,
-        meebook_list_events_service,
-        schema=LIST_MEEBOOK_EVENTS_SCHEMA,
-        supports_response=core.SupportsResponse.ONLY,
-    )
+        hass.services.async_register(
+            DOMAIN,
+            LIST_MEEBOOK_EVENTS_SERVICE_NAME,
+            meebook_list_events_service,
+            schema=LIST_MEEBOOK_EVENTS_SCHEMA,
+            supports_response=core.SupportsResponse.ONLY,
+        )
 
 
 

--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -226,8 +226,8 @@ class AulaSensor(Entity):
     async def async_get_meebook_weekplan (
         self, start_date: date, end_date: date
     ):
-        name = self._child["name"]
         try:
+            name = self._child["name"].split()[0]
             plan = self._client.meebook_weekplan[name]
             return {"entries": {day: tasks for day, tasks in plan.items() if day >= start_date and day <= end_date and len(tasks["tasks"]) > 0 }}
         except:

--- a/custom_components/aula/services.yaml
+++ b/custom_components/aula/services.yaml
@@ -1,0 +1,16 @@
+list_meebook_events:
+  target:
+    entity:
+      domain: sensor
+  fields:
+    start_date:
+      example: "2022-03-22"
+      selector:
+        date:
+    end_date:
+      example: "2022-03-22"
+      selector:
+        date:
+    duration:
+      selector:
+        duration:


### PR DESCRIPTION
Dette tilføjer en service, lidt alá `calendar.list_events`, der returnerer meebook weekplan-data for et givent tidspunkt.

Planen er hver aften at bruge TTS til at fortælle hvilke lektier etc. der skal være lavet til dagen efter.

![image](https://github.com/scaarup/aula/assets/2759794/0f28e945-a4dc-42b8-81bd-0af9bee76358)


## Tanker...
- Jeg kan forstå, at "ugeplaner" er kan betyde flere ting, og at forskellige skoler anvender det på forskellige måder. Forsøget her er baseret på mine egne børns data.

- Servicen tager *sensor* som parameter. Entity-pickeren vil så vise alle sensorer, hvilket ikke er optimalt. Idéer til anden tilgang modtages gerne!