### PR TITLE
Add primaryResource as location if present

### DIFF
--- a/custom_components/aula/calendar.py
+++ b/custom_components/aula/calendar.py
@@ -92,6 +92,7 @@ class CalendarData:
                 summary = c['title']
                 start = datetime.strptime(c['startDateTime'],"%Y-%m-%dT%H:%M:%S%z")
                 end = datetime.strptime(c['endDateTime'],"%Y-%m-%dT%H:%M:%S%z")
+                location = c.get('primaryResource', {}).get('name')
                 vikar = 0
                 for p in c['lesson']['participants']:
                     if p['participantRole'] == 'substituteTeacher':
@@ -112,6 +113,7 @@ class CalendarData:
                     summary=str(summary) + ", " + str(teacher),
                     start = start,
                     end = end,
+                    location=location,
                 )
                 events.append(event)
         return events


### PR DESCRIPTION
If a primary resource exists, the name of it will be used as the location of the CalendarEvent

The Location does not show in the built-in Calendar dashboard, but will show in e.g. Atomic Calender Revive or other calendars supporting locations:
![image](https://github.com/user-attachments/assets/3f165b54-0911-4eee-8e76-10165752f47c)
