### PR TITLE
Only unload calendar platform if schoolschedule is enabled

### DIFF
--- a/custom_components/aula/__init__.py
+++ b/custom_components/aula/__init__.py
@@ -126,8 +126,13 @@ async def async_unload_entry(
     hass: core.HomeAssistant, entry: config_entries.ConfigEntry
 ) -> bool:
     """Unload a config entry."""
-    # Unload all platforms that may have been set up
-    platforms_to_unload = ["sensor", "binary_sensor", "calendar"]
+    # Only unload platforms that were actually set up
+    platforms_to_unload = ["sensor", "binary_sensor"]
+
+    # Only include calendar if schoolschedule was enabled
+    if entry.data.get(CONF_SCHOOLSCHEDULE, True):
+        platforms_to_unload.append("calendar")
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms_to_unload)
 
     # Remove options_update_listener.


### PR DESCRIPTION
Bug: On every MitID token refresh, the integration will reload. Even "calendar" which is not even loaded if user has not selected to enable school schedules.