### PR TITLE
Expose the location name as state when daily info status is 7

### DIFF
--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -148,6 +148,7 @@ class AulaSensor(Entity):
         3 = KOMMET/TIL STEDE
         4 = PÅ TUR
         5 = SOVER
+        7 = PHYSICAL PLACEMENT (Mere info in "location")
         8 = HENTET/GÅET
         """
         if self._client.presence[str(self._child["id"])] == 1:
@@ -170,6 +171,8 @@ class AulaSensor(Entity):
                 "15",
             ]
             daily_info = self._client._daily_overview[str(self._child["id"])]
+            if daily_info["status"] == 7 and daily_info.get('location') is not None:
+                return daily_info['location'].get('name', states[daily_info["status"]])
             return states[daily_info["status"]]
         else:
             _LOGGER.debug("Setting state to n/a for child " + str(self._child["id"]))


### PR DESCRIPTION
The 7 status indicates a physical placement is set. This appears to be potentially unique per school/institution, but the id and name is included in the getDailyOverview response.

It's not entirely clear if this is available in other statuses, so I've kept it to safe for now. It could probably be simplified to just checking if location is not None.
I realize these are available as attributes on the sensor, but getting it as the state makes it easier to display and you get a better history.

I've captured two responses from my kids school with the relevant snippets below:

    status: 7
    location:
      id: XXXX
      name: Ude
      description: ""
      symbol: icon-Aula_sfo_slide
      startTime: null
      endTime: null
      startDate: null
      endDate: null
      isDeactivated: false
      weekDayMask: null
      isDateIntervalsEnabled: false
      isTimeIntervalsEnabled: false
      isWeekdaysEnabled: false


    status: 7
    location:
      id: XXXX
      name: Hal
      description: ""
      symbol: icon-Aula_sfo_gymnastic_hall
      startTime: null
      endTime: null
      startDate: null
      endDate: null
      isDeactivated: false
      weekDayMask: null
      isDateIntervalsEnabled: false
      isTimeIntervalsEnabled: false
      isWeekdaysEnabled: false