### PR TITLE
EasyIQ (0001): surface API errors and schema mismatches at WARNING level

### DIFF
--- a/custom_components/aula/client.py
+++ b/custom_components/aula/client.py
@@ -821,6 +821,19 @@ class Client:
                         _LOGGER.debug(
                             "EasyIQ Opgaver response " + str(ugeplaner.json())
                         )
+                        easyiq_payload = ugeplaner.json()
+                        if isinstance(easyiq_payload, dict) and easyiq_payload.get(
+                            "ErrorCode"
+                        ):
+                            _LOGGER.warning(
+                                "EasyIQ 0001 rejected weekplan request for %s "
+                                "(institution header %s, week %s): %s %s",
+                                first_name,
+                                self._institutionProfiles[0],
+                                week,
+                                easyiq_payload.get("ErrorCode"),
+                                easyiq_payload.get("ErrorDescription"),
+                            )
                         _ugep = (
                             "<h2>"
                             # + ugeplaner.json()["Weekplan"]["ActivityName"]
@@ -900,9 +913,20 @@ class Client:
                                         )
                                     _ugep = _ugep + str(i["description"]) + "<br>"
                                 else:
-                                    _LOGGER.debug("None")
-                        except KeyError:
-                            _LOGGER.debug("None")
+                                    _LOGGER.debug(
+                                        "EasyIQ event for %s skipped: unrecognised start format %r",
+                                        first_name,
+                                        i.get("start"),
+                                    )
+                        except KeyError as exc:
+                            _LOGGER.warning(
+                                "EasyIQ weekplan for %s missing expected key %s; response keys=%s",
+                                first_name,
+                                exc,
+                                list(easyiq_payload.keys())
+                                if isinstance(easyiq_payload, dict)
+                                else type(easyiq_payload).__name__,
+                            )
 
                         if thisnext == "this":
                             self.ugep_attr[first_name] = _ugep


### PR DESCRIPTION
## Summary

The legacy EasyIQ block (widget `0001`) wraps the `Events` iteration in a bare:

```python
try:
    for i in ugeplaner.json()["Events"]:
        ...
except KeyError:
    _LOGGER.debug("None")
```

Any non-`Events` response — including the EasyIQ error envelope `{"ErrorCode": "1", "ErrorDescription": "..."}`, which the API now returns aggressively for schools that have migrated to SkolePortal but still have widget `0001` listed — falls into the except and is logged at DEBUG level as the literal string `"None"`. Downstream, the sensor attribute renders as just `<h2> Uge NN</h2>` for every child with no log line at default verbosity indicating why.

This PR makes two small additions, no behaviour change for happy paths:

1. After the existing DEBUG dump of the response, detect the EasyIQ error envelope shape and log it as a `WARNING` naming widget id, child, institution header, week, `ErrorCode` and `ErrorDescription`.
2. Replace `except KeyError: _LOGGER.debug("None")` with a `WARNING` that names the missing key and the response keys it did see — so the next EasyIQ schema change isn't silent either.

Genuine empty weeks for a child still produce no warnings (the date-format check still DEBUG-logs to a `"None"`-style line, just with more context).

## Why

Filed as a follow-up to the drive-by suggestion on #352. The silent-failure mode cost a couple of hours of diagnostic time before enabling debug logging revealed the actual `ErrorCode`/`ErrorDescription` payload. Surfacing it at default verbosity should save the next person the same archaeology.

## Test plan

- [x] Module syntax-checks clean (`python3 -c 'import ast; ast.parse(...)'`).
- [x] Verified locally on HAOS against the equivalent surfacing path (applied as part of an earlier patch); the WARNING fires once per child per week when EasyIQ returns the license error, and the sensor body is unchanged for genuine empty weeks.
- [ ] @MartinSaaby offered on #352 to verify the WARNING fires correctly on a SkolePortal-only school whose widget list still contains `0001`.