### PR TITLE
Fix MitID external auth URL for Home Assistant 2026.8

### DIFF
--- a/custom_components/aula/config_flow.py
+++ b/custom_components/aula/config_flow.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.helpers import network
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_registry import (
     async_entries_for_config_entry,
@@ -185,10 +186,17 @@ class AulaCustomConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Start authentication task
             self.hass.async_create_task(self._authenticate_async(session_data))
+            try:
+                base_url = network.get_url(
+                    self.hass,
+                    require_current_request=True,
+                )
+            except network.NoURLAvailableError:
+                base_url = network.get_url(self.hass)
 
             return self.async_external_step(
                 step_id="authenticate",
-                url=f"/api/aula/auth/{self.flow_id}",
+                url=f"{base_url.rstrip('/')}/api/aula/auth/{self.flow_id}",
             )
 
         if session_data.get("completed"):


### PR DESCRIPTION
This PR fixes the MitID authentication flow on Home Assistant 2026.8. Issue #359 

The Aula config flow currently returns a relative URL in `async_external_step()`:

```python
url=f"/api/aula/auth/{self.flow_id}"
```

Home Assistant 2026.8 now sanitizes external-step URLs and only opens absolute `http://` or `https://` URLs. As a result, the MitID authentication request is started successfully and reaches the MitID app, but the Aula authentication page containing the QR code is never opened.

The change makes the external-step URL absolute by using Home Assistant's URL helper instead of hardcoding a hostname.

I confirmed the issue by manually opening the returned `/api/aula/auth/<flow_id>` path as an absolute URL. The MitID authentication page and QR code then appeared and the login completed successfully.

This keeps the existing `async_external_step()` design and only adapts the URL generation to the current Home Assistant frontend behaviour.