### PR TITLE
Fix FAILED_UNLOAD: forward calendar platform in setup

### DIFF
--- a/custom_components/aula/__init__.py
+++ b/custom_components/aula/__init__.py
@@ -107,9 +107,14 @@ async def async_setup_entry(
     # Fetch initial data before setting up platforms
     await hass.async_add_executor_job(client.update_data)
 
-    await hass.config_entries.async_forward_entry_setups(
-        entry, ["sensor", "binary_sensor"]
-    )
+    # Keep this list in sync with async_unload_entry so setup and unload are
+    # symmetric. Previously only sensor/binary_sensor were forwarded here while
+    # async_unload_entry also tried to unload "calendar", which raised and left
+    # the entry stuck in the non-recoverable FAILED_UNLOAD state on reload.
+    platforms = ["sensor", "binary_sensor"]
+    if entry.data.get(CONF_SCHOOLSCHEDULE, True):
+        platforms.append("calendar")
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
     return True
 
 


### PR DESCRIPTION
## Summary

Fixes #362.

`async_setup_entry` only forwarded `["sensor", "binary_sensor"]`, but
`async_unload_entry` also unloads `calendar` when `schoolschedule` is enabled.
Since `calendar` was never set up, `async_unload_platforms` raised, unload
failed, and the config entry landed in the non-recoverable `FAILED_UNLOAD`
state on reload:

```
... cannot be unloaded because it is in the non recoverable state
ConfigEntryState.FAILED_UNLOAD
```

It also meant the school-schedule calendar entities (`calendar.py`) were never
created for users with `schoolschedule` enabled.

## Change

Build the setup platform list the same way unload does, so setup and unload are
symmetric:

```python
platforms = ["sensor", "binary_sensor"]
if entry.data.get(CONF_SCHOOLSCHEDULE, True):
    platforms.append("calendar")
await hass.config_entries.async_forward_entry_setups(entry, platforms)
```

## Result

- Reloading the entry works instead of wedging it in `FAILED_UNLOAD`.
- The calendar entities now actually appear when `schoolschedule` is enabled.

Tested on Home Assistant Core 2026.8.1.
