### PR TITLE
Fix mu_opgaver_next attribute typo and support MU Opgaver at schools without widget 0030

### DIFF
--- a/custom_components/aula/client.py
+++ b/custom_components/aula/client.py
@@ -5,6 +5,8 @@ import pytz
 import asyncio
 import threading
 import datetime
+import base64
+import urllib.parse
 from bs4 import BeautifulSoup
 import json, re
 from .const import (
@@ -20,6 +22,56 @@ from .aula_login_client.client import AulaLoginClient
 from .aula_login_client.exceptions import AulaAuthenticationError
 
 _LOGGER = logging.getLogger(__name__)
+
+# Widgets that can mint a token for the Min Uddannelse "opgaveliste" endpoint,
+# in order of preference. 0030 is the dedicated "MU Opgaver" widget; 0023
+# ("MinUddannelse - SSO") is accepted by the same endpoint and is available at
+# schools that do not expose 0030 to guardians.
+MU_OPGAVER_WIDGETS = ("0030", "0023")
+
+
+def decode_mu_deeplink(url):
+    """Return the MinUddannelse page URL embedded in an opgave "url" field.
+
+    Min Uddannelse returns a redirect wrapper whose last path segment is the
+    base64 of the (url-encoded) real page URL. That redirect only works inside
+    an authenticated browser session, so linking to the decoded URL directly
+    gives a link that works from a dashboard. Returns None if it cannot be
+    decoded.
+    """
+    if not url:
+        return None
+    try:
+        encoded = url.rsplit("/", 1)[-1]
+        encoded = encoded + "=" * (-len(encoded) % 4)
+        decoded = urllib.parse.unquote(base64.b64decode(encoded).decode("utf-8"))
+        return decoded or None
+    except Exception:
+        _LOGGER.debug("Could not decode Min Uddannelse deep link: " + str(url))
+        return None
+
+
+def format_mu_opgaver(opgaver, first_name):
+    """Render one child's opgaver as the HTML used for the sensor attribute."""
+    _ugep = ""
+    for opgave in opgaver:
+        if opgave["kuvertnavn"].split()[0] != first_name:
+            continue
+        title = opgave["title"]
+        link = decode_mu_deeplink(opgave.get("url") or "")
+        if link:
+            title = '<a href="' + link + '" target="_blank">' + title + "</a>"
+        _ugep = _ugep + "<h2>" + title + "</h2>"
+        _ugep = _ugep + "<h3>" + opgave["kuvertnavn"] + "</h3>"
+        _ugep = _ugep + "Ugedag: " + opgave["ugedag"] + "<br>"
+        _ugep = _ugep + "Type: " + opgave["opgaveType"] + "<br>"
+        for hold in opgave["hold"]:
+            _ugep = _ugep + "Hold: " + hold["navn"] + "<br>"
+        try:
+            _ugep = _ugep + "Forløb: " + opgave["forloeb"]["navn"]
+        except (KeyError, TypeError):
+            _LOGGER.debug("Did not find forloeb key: " + str(opgave))
+    return _ugep
 
 
 class Client:
@@ -901,15 +953,19 @@ class Client:
 
             if len(self.widgets) == 0:
                 self.get_widgets()
-            if "0030" not in self.widgets:
+            mu_widget = next(
+                (widget for widget in MU_OPGAVER_WIDGETS if widget in self.widgets),
+                None,
+            )
+            if mu_widget is None:
                 _LOGGER.error(
-                    "You have enabled Min Uddannelse Opgaver, but we cannot find any supported widgets (0030) in Aula."
+                    "You have enabled Min Uddannelse Opgaver, but we cannot find any supported widgets (0030,0023) in Aula."
                 )
 
             def mu_opgaver(week, thisnext):
-                if "0030" in self.widgets:
-                    _LOGGER.debug("In the MU Opgaver flow")
-                    token = self.get_token("0030")
+                if mu_widget is not None:
+                    _LOGGER.debug("In the MU Opgaver flow, using widget " + mu_widget)
+                    token = self.get_token(mu_widget)
                     get_payload = (
                         "/opgaveliste?assuranceLevel=2&childFilter="
                         + childUserIds
@@ -933,23 +989,7 @@ class Client:
                     for full_name in self._childnames.items():
                         name_parts = full_name[1].split()
                         first_name = name_parts[0]
-                        _ugep = ""
-                        for i in opgaver_list:
-                            _LOGGER.debug(
-                                "i kuvertnavn split " + str(i["kuvertnavn"].split()[0])
-                            )
-                            _LOGGER.debug("first_name " + first_name)
-                            if i["kuvertnavn"].split()[0] == first_name:
-                                _ugep = _ugep + "<h2>" + i["title"] + "</h2>"
-                                _ugep = _ugep + "<h3>" + i["kuvertnavn"] + "</h3>"
-                                _ugep = _ugep + "Ugedag: " + i["ugedag"] + "<br>"
-                                _ugep = _ugep + "Type: " + i["opgaveType"] + "<br>"
-                                for h in i["hold"]:
-                                    _ugep = _ugep + "Hold: " + h["navn"] + "<br>"
-                                try:
-                                    _ugep = _ugep + "Forløb: " + i["forloeb"]["navn"]
-                                except:
-                                    _LOGGER.debug("Did not find forloeb key: " + str(i))
+                        _ugep = format_mu_opgaver(opgaver_list, first_name)
                         if thisnext == "this":
                             self.mu_opgaver_attr[first_name] = _ugep
                         elif thisnext == "next":

--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -212,7 +212,7 @@ class AulaSensor(Entity):
             except:
                 attributes["mu_opgaver"] = "Min Uddannelse Opgaver not available"
             try:
-                attributes["mu_opgaver_next"] = self._client.mu_opgavernext_attr[
+                attributes["mu_opgaver_next"] = self._client.mu_opgaver_next_attr[
                     self._child["name"].split()[0]
                 ]
             except:

--- a/tests/fixtures/mu_opgaveliste.json
+++ b/tests/fixtures/mu_opgaveliste.json
@@ -1,0 +1,33 @@
+{
+  "opgaver": [
+    {
+      "id": "11111111-2222-3333-4444-555555555555",
+      "title": "Ugeplan 4.B",
+      "kuvertnavn": "Test Testesen",
+      "unilogin": "test1234",
+      "ugedag": "Mandag",
+      "ugenummer": "2026-W33",
+      "opgaveType": "SimpelLektie",
+      "hold": [{ "navn": "Ugeplan 4B" }],
+      "forloeb": { "navn": "Test Forløb" },
+      "afleveringsdato": null,
+      "antalElever": 0,
+      "antalFaerdige": 0,
+      "erFaerdig": false,
+      "placering": null,
+      "placeringTidspunkt": null,
+      "url": "https://api.minuddannelse.net/aula/redirect/123456/aHR0cHMlM2ElMmYlMmZ3d3cubWludWRkYW5uZWxzZS5uZXQlMmZOb2RlJTJmbWludWdlJTJmMTIzNDU2NyUzZnVnZSUzZDIwMjYtVzMz"
+    },
+    {
+      "id": "66666666-7777-8888-9999-000000000000",
+      "title": "Matematik afleveringsopgave",
+      "kuvertnavn": "Anden Testesen",
+      "unilogin": "test5678",
+      "ugedag": "Onsdag",
+      "ugenummer": "2026-W33",
+      "opgaveType": "SimpelLektie",
+      "hold": [{ "navn": "7B Matematik" }],
+      "url": "not-a-valid-deeplink"
+    }
+  ]
+}

--- a/tests/test_mu_opgaver.py
+++ b/tests/test_mu_opgaver.py
@@ -1,0 +1,89 @@
+import os
+import pytest
+import json
+
+from custom_components.aula.client import (
+    MU_OPGAVER_WIDGETS,
+    decode_mu_deeplink,
+    format_mu_opgaver,
+)
+
+
+def load_json_fixture(filename):
+    fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
+    with open(fixture_path) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def sample__opgaveliste():
+    return load_json_fixture("mu_opgaveliste.json")["opgaver"]
+
+
+def test_widget_preference_order():
+    assert MU_OPGAVER_WIDGETS == ("0030", "0023")
+
+
+def test_widget_selection__prefers_0030():
+    widgets = {"0023": "MinUddannelse - SSO", "0030": "MU Opgaver"}
+    selected = next((w for w in MU_OPGAVER_WIDGETS if w in widgets), None)
+    assert selected == "0030"
+
+
+def test_widget_selection__falls_back_to_0023():
+    widgets = {"0023": "MinUddannelse - SSO", "0029": "MinUddannelse – Ugenoter"}
+    selected = next((w for w in MU_OPGAVER_WIDGETS if w in widgets), None)
+    assert selected == "0023"
+
+
+def test_widget_selection__none_available():
+    widgets = {"0029": "MinUddannelse – Ugenoter"}
+    selected = next((w for w in MU_OPGAVER_WIDGETS if w in widgets), None)
+    assert selected is None
+
+
+def test_decode_deeplink():
+    url = (
+        "https://api.minuddannelse.net/aula/redirect/123456/"
+        "aHR0cHMlM2ElMmYlMmZ3d3cubWludWRkYW5uZWxzZS5uZXQlMmZOb2RlJTJmbWludWdlJTJmMTIzNDU2NyUzZnVnZSUzZDIwMjYtVzMz"
+    )
+    assert (
+        decode_mu_deeplink(url)
+        == "https://www.minuddannelse.net/Node/minuge/1234567?uge=2026-W33"
+    )
+
+
+def test_decode_deeplink__invalid_returns_none():
+    assert decode_mu_deeplink("not-a-valid-deeplink") is None
+    assert decode_mu_deeplink("") is None
+
+
+def test_format__matching_child(sample__opgaveliste):
+    html = format_mu_opgaver(sample__opgaveliste, "Test")
+    assert (
+        '<h2><a href="https://www.minuddannelse.net/Node/minuge/1234567?uge=2026-W33"'
+        ' target="_blank">Ugeplan 4.B</a></h2>' in html
+    )
+    assert "<h3>Test Testesen</h3>" in html
+    assert "Ugedag: Mandag<br>" in html
+    assert "Type: SimpelLektie<br>" in html
+    assert "Hold: Ugeplan 4B<br>" in html
+    assert "Forløb: Test Forløb" in html
+    # opgaver belonging to another child are not included
+    assert "Matematik afleveringsopgave" not in html
+
+
+def test_format__undecodable_url_falls_back_to_plain_title(sample__opgaveliste):
+    html = format_mu_opgaver(sample__opgaveliste, "Anden")
+    assert "<h2>Matematik afleveringsopgave</h2>" in html
+    assert "<a href=" not in html
+
+
+def test_format__missing_forloeb_is_tolerated(sample__opgaveliste):
+    # the second fixture entry has no "forloeb" key at all
+    html = format_mu_opgaver(sample__opgaveliste, "Anden")
+    assert "Forløb:" not in html
+
+
+def test_format__no_opgaver_for_child(sample__opgaveliste):
+    assert format_mu_opgaver(sample__opgaveliste, "Ukendt") == ""


### PR DESCRIPTION
Two fixes and one small enhancement to the Min Uddannelse Opgaver flow. Issues are disabled on the repo, so the full context is below.

## Problem 1 — `mu_opgaver_next` is always "Not available"

`sensor.py` reads the next-week opgaver from `mu_opgavernext_attr`, but `client.py` only ever writes `mu_opgaver_next_attr` (note the extra `_`):

```python
# client.py
mu_opgaver_next_attr = {}
...
elif thisnext == "next":
    self.mu_opgaver_next_attr[first_name] = _ugep
```

```python
# sensor.py
attributes["mu_opgaver_next"] = self._client.mu_opgavernext_attr[...]
```

`mu_opgavernext_attr` is never defined or assigned anywhere in the integration (`grep -rn mu_opgavernext_attr` matches only this read), so the lookup raises `AttributeError` on every update. The bare `except:` swallows it and the attribute falls back to `"Not available"` — for every school and every child.

## Problem 2 — schools without widget 0030 get no opgaver at all

The MU Opgaver flow is gated on widget `0030` being present. Our school exposes `0029` (MinUddannelse – Ugenoter), `0023` (MinUddannelse – SSO), `0072` (MU Elev – fravær) and `0138` (H&H Forældreportalen), but **not** `0030`. The result is this error every single update cycle, and `mu_opgaver` never populates:

```
You have enabled Min Uddannelse Opgaver, but we cannot find any supported widgets (0030) in Aula.
```

The opgaver do exist and are visible on minuddannelse.net. This is not a cosmetic problem: one of our children's classes publishes their **weekly plan as an opgave** rather than as an ugenote, so without 0030 the whole ugeplan is invisible in Home Assistant.

**Finding:** `https://api.minuddannelse.net/aula/opgaveliste` accepts a token minted for widget **0023** — same parameters, HTTP 200, same payload shape. Verified against a live account on 2026-08-11.

## Solution

**Widget fallback** — try `0030` first, fall back to `0023`:

```python
MU_OPGAVER_WIDGETS = ("0030", "0023")
...
mu_widget = next((w for w in MU_OPGAVER_WIDGETS if w in self.widgets), None)
```

Schools that expose `0030` keep using it, so existing behaviour is unchanged.

**Link to the opgave** — the `opgaveliste` response contains metadata only (title, ugedag, opgaveType, hold, forloeb) with no content field, but every opgave carries a `url` whose last path segment is the base64 of the real MinUddannelse page URL. `decode_mu_deeplink()` decodes it and the title is rendered as a link, so the plan is one tap away from a markdown card. Note the raw `url` value is an SSO redirect that only resolves inside an authenticated browser session (server-side it lands on `/Error/IngenAdgang`), which is why the decoded target is used instead. If it cannot be decoded, the title renders exactly as before.

**Small refactor for testability** — the per-child rendering loop is extracted into a module-level `format_mu_opgaver(opgaver, first_name)`, mirroring how `parseCalendarLesson` is structured in `calendar.py`. Output is byte-for-byte identical to the previous implementation when no link can be decoded (verified against the old algorithm). The bare `except:` around `forloeb` is narrowed to `except (KeyError, TypeError):`.

## Testing

`tests/test_mu_opgaver.py` adds 10 tests over a new anonymised `tests/fixtures/mu_opgaveliste.json`: widget preference order and fallback selection, deep-link decoding (valid, malformed, empty), per-child filtering, the plain-title fallback, and tolerance of a missing `forloeb` key.

```
12 passed
```

Also running all three changes on a live install (HA 2026.8.1) since 2026-08-11: `mu_opgaver` and `mu_opgaver_next` both populate correctly at a school that exposes 0023 but not 0030, and the titles link through to the correct week in MinUddannelse.
