### PR TITLE
Fix ugeplan when Min Uddannelse Ugenoter widget is not exposed.

### DIFF
--- a/custom_components/aula/client.py
+++ b/custom_components/aula/client.py
@@ -29,6 +29,12 @@ _LOGGER = logging.getLogger(__name__)
 # schools that do not expose 0030 to guardians.
 MU_OPGAVER_WIDGETS = ("0030", "0023")
 
+# Widgets that can mint a token for the Min Uddannelse "ugebrev" endpoint,
+# in order of preference. 0029 is the dedicated "Ugenoter" widget; 0023
+# ("MinUddannelse - SSO") is accepted by the same endpoint and is available at
+# schools that do not expose 0029 to guardians.
+MU_UGEPLAN_WIDGETS = ("0029", "0023")
+
 
 def decode_mu_deeplink(url):
     """Return the MinUddannelse page URL embedded in an opgave "url" field.
@@ -1020,23 +1026,27 @@ class Client:
 
             if len(self.widgets) == 0:
                 self.get_widgets()
+            mu_uge_widget = next(
+                (widget for widget in MU_UGEPLAN_WIDGETS if widget in self.widgets),
+                None,
+            )
             if (
-                "0029" not in self.widgets
+                mu_uge_widget is None
                 and "0004" not in self.widgets
                 and "0062" not in self.widgets
                 and "0001" not in self.widgets
             ):
                 _LOGGER.error(
-                    "You have enabled ugeplaner, but we cannot find any supported widgets (0029,0004,0001) in Aula."
+                    "You have enabled ugeplaner, but we cannot find any supported widgets (0029,0023,0004,0001) in Aula."
                 )
-            if "0029" in self.widgets and "0004" in self.widgets:
+            if mu_uge_widget is not None and "0004" in self.widgets:
                 _LOGGER.warning(
                     "Multiple sources for ugeplaner is untested and might cause problems."
                 )
 
             def ugeplan(week, thisnext):
-                if "0029" in self.widgets:
-                    token = self.get_token("0029")
+                if mu_uge_widget is not None:
+                    token = self.get_token(mu_uge_widget)
                     get_payload = (
                         "/ugebrev?assuranceLevel=2&childFilter="
                         + childUserIds

--- a/custom_components/aula/client.py
+++ b/custom_components/aula/client.py
@@ -34,6 +34,12 @@ _LOGGER = logging.getLogger(__name__)
 # schools that do not expose 0030 to guardians.
 MU_OPGAVER_WIDGETS = ("0030", "0023")
 
+# Widgets that can mint a token for the Min Uddannelse "ugebrev" endpoint,
+# in order of preference. 0029 is the dedicated "Ugenoter" widget; 0023
+# ("MinUddannelse - SSO") is accepted by the same endpoint and is available at
+# schools that do not expose 0029 to guardians.
+MU_UGEPLAN_WIDGETS = ("0029", "0023")
+
 # Widgets that can mint a token for the EasyIQ Ugeplan endpoint,
 # in order of preference.
 EASYIQ_WIDGETS = ("0001", "0128", "00142", "0142")
@@ -1058,23 +1064,27 @@ class Client:
 
             if len(self.widgets) == 0:
                 self.get_widgets()
+            mu_uge_widget = next(
+                (widget for widget in MU_UGEPLAN_WIDGETS if widget in self.widgets),
+                None,
+            )
             if (
-                "0029" not in self.widgets
+                mu_uge_widget is None
                 and "0004" not in self.widgets
                 and "0062" not in self.widgets
                 and not any(widget in self.widgets for widget in EASYIQ_WIDGETS)
             ):
                 _LOGGER.error(
-                    "You have enabled ugeplaner, but we cannot find any supported widgets (0029,0004,0062,EasyIQ) in Aula."
+                    "You have enabled ugeplaner, but we cannot find any supported widgets (0029,0023,0004,0062,EasyIQ) in Aula."
                 )
-            if "0029" in self.widgets and "0004" in self.widgets:
+            if mu_uge_widget is not None and "0004" in self.widgets:
                 _LOGGER.warning(
                     "Multiple sources for ugeplaner is untested and might cause problems."
                 )
 
             def ugeplan(week, thisnext):
-                if "0029" in self.widgets:
-                    token = self.get_token("0029")
+                if mu_uge_widget is not None:
+                    token = self.get_token(mu_uge_widget)
                     get_payload = (
                         "/ugebrev?assuranceLevel=2&childFilter="
                         + childUserIds

--- a/tests/test_mu_opgaver.py
+++ b/tests/test_mu_opgaver.py
@@ -4,6 +4,7 @@ import json
 
 from custom_components.aula.client import (
     MU_OPGAVER_WIDGETS,
+    MU_UGEPLAN_WIDGETS,
     EASYIQ_WIDGETS,
     decode_mu_deeplink,
     format_mu_opgaver,
@@ -40,6 +41,28 @@ def test_widget_selection__falls_back_to_0023():
 def test_widget_selection__none_available():
     widgets = {"0029": "MinUddannelse – Ugenoter"}
     selected = next((w for w in MU_OPGAVER_WIDGETS if w in widgets), None)
+    assert selected is None
+
+
+def test_ugeplan_widget_preference_order():
+    assert MU_UGEPLAN_WIDGETS == ("0029", "0023")
+
+
+def test_ugeplan_widget_selection__prefers_0029():
+    widgets = {"0023": "MinUddannelse - SSO", "0029": "MinUddannelse – Ugenoter"}
+    selected = next((w for w in MU_UGEPLAN_WIDGETS if w in widgets), None)
+    assert selected == "0029"
+
+
+def test_ugeplan_widget_selection__falls_back_to_0023():
+    widgets = {"0023": "MinUddannelse - SSO", "0072": "MU Elev - fravær"}
+    selected = next((w for w in MU_UGEPLAN_WIDGETS if w in widgets), None)
+    assert selected == "0023"
+
+
+def test_ugeplan_widget_selection__none_available():
+    widgets = {"0001": "EasyIQ"}
+    selected = next((w for w in MU_UGEPLAN_WIDGETS if w in widgets), None)
     assert selected is None
 
 


### PR DESCRIPTION
Some guardian profiles no longer list widget `0029` (Min Uddannelse Ugenoter), so ugeplan was skipped even when Min Uddannelse still serves `/ugebrev`.

Accept widget `0023` (MinUddannelse - SSO) as a token source for ugeplan, same fallback already used for MU Opgaver (`0030` → `0023`).

Prefer `0029` when it is present; otherwise use `0023`. Meebook / EasyIQ / Systematic sources are unchanged.
