### PR TITLE
Forward the calendar platform once, not twice

### DIFF
--- a/custom_components/aula/sensor.py
+++ b/custom_components/aula/sensor.py
@@ -18,7 +18,6 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 from .const import (
-    CONF_SCHOOLSCHEDULE,
     CONF_UGEPLAN,
     CONF_MU_OPGAVER,
     CONF_MITID_USERNAME,
@@ -92,11 +91,6 @@ async def async_setup_entry(
                 entities.append(AulaSensor(hass, coordinator, child))
         else:
             entities.append(AulaSensor(hass, coordinator, child))
-    # We have data and can now set up the calendar platform:
-    if config[CONF_SCHOOLSCHEDULE]:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setups(config_entry, ["calendar"])
-        )
 
     global ugeplan
     global mu_opgaver


### PR DESCRIPTION
__init__.py forwards ["sensor", "binary_sensor", "calendar"], then sensor.py forwards ["calendar"] again via async_create_task; whichever lands second raises "Config entry ... for aula.calendar has already been setup!". Being a race, it only hits some startups.

Remove the sensor.py forward. Its rationale ("We have data and can now set up the calendar platform") predates __init__.py awaiting client.update_data() before forwarding, and calendar.py fetches its own data anyway. This drops the last use of CONF_SCHOOLSCHEDULE in sensor.py, and its import.