### PR TITLE
Bump Aula API version to v24

### DIFF
--- a/custom_components/aula/const.py
+++ b/custom_components/aula/const.py
@@ -16,7 +16,7 @@ https://github.com/scaarup/aula/issues
 
 DOMAIN = "aula"
 API = "https://www.aula.dk/api/v"
-API_VERSION = "22"
+API_VERSION = "24"
 MIN_UDDANNELSE_API = "https://api.minuddannelse.net/aula"
 MEEBOOK_API = "https://app.meebook.com/aulaapi"
 SYSTEMATIC_API = "https://systematic-momo.dk/api/aula"


### PR DESCRIPTION
Aula now returns HTTP 410 for API v22, breaking all requests. Bump the API version to v24 which is the version currently served by aula.dk.